### PR TITLE
fix: remove unnecessary creation of traces folder during Traces initialisation

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/tracers/main_tracer.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/tracers/main_tracer.py
@@ -119,9 +119,6 @@ class AgenticTracing(
         self.component_network_calls = {}  # Store network calls per component
         self.component_user_interaction = {}
 
-        # Create output directory if it doesn't exist
-        self.output_dir = Path("./traces")  # Using default traces directory
-        self.output_dir.mkdir(exist_ok=True)
 
     def start_component(self, component_id: str):
         """Start tracking network calls for a component"""


### PR DESCRIPTION
## Description
- Remove unnecessary creation of traces folder during Traces initialisation

## Related Issue
- Earlier a dummy folder traces was getting created during Trace initialisation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the automatic creation of the directory used for storing trace outputs, which may require manual setup if necessary.  
	- The tracing process remains unchanged aside from this adjustment to output management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->