### PR TITLE
Raise Exceptions during Scan

### DIFF
--- a/ragaai_catalyst/redteaming.py
+++ b/ragaai_catalyst/redteaming.py
@@ -1,8 +1,8 @@
 import logging
 import os
-from typing import Callable, Optional, List
+from typing import Callable, Optional
 
-import giskard
+import giskard as scanner
 import pandas as pd
 
 logging.getLogger('giskard.core').disabled = True
@@ -76,7 +76,7 @@ class RedTeaming:
                 raise ValueError(f"Invalid evaluators: {invalid_evaluators}. "
                                  f"Allowed evaluators: {supported_evaluators}.")
 
-        model_instance = giskard.Model(
+        model_instance = scanner.Model(
             model=model,
             model_type="text_generation",
             name="RagaAI's Scan",
@@ -85,8 +85,8 @@ class RedTeaming:
         )
 
         try:
-            report = giskard.scan(model_instance, only=evaluators, raise_exceptions=True) if evaluators \
-                     else giskard.scan(model_instance, raise_exceptions=True)
+            report = scanner.scan(model_instance, only=evaluators, raise_exceptions=True) if evaluators \
+                     else scanner.scan(model_instance, raise_exceptions=True)
         except Exception as e:
             raise RuntimeError(f"Error occurred during model scan: {str(e)}")
 
@@ -143,4 +143,4 @@ class RedTeaming:
         if selected_model is None:
             raise ValueError(f"Unsupported provider: {provider}")
 
-        giskard.llm.set_llm_model(selected_model)
+        scanner.llm.set_llm_model(selected_model)

--- a/ragaai_catalyst/redteaming.py
+++ b/ragaai_catalyst/redteaming.py
@@ -1,5 +1,3 @@
-import asyncio
-import inspect
 import logging
 import os
 from typing import Callable, Optional
@@ -66,6 +64,8 @@ class RedTeaming:
         :param save_report: Boolean flag indicating whether to save the scan report as a CSV file.
         :return: A DataFrame containing the scan report.
         """
+        import asyncio
+        import inspect
 
         self.set_scanning_model(self.provider, self.model)
 

--- a/ragaai_catalyst/redteaming.py
+++ b/ragaai_catalyst/redteaming.py
@@ -85,7 +85,8 @@ class RedTeaming:
         )
 
         try:
-            report = giskard.scan(model_instance, only=evaluators) if evaluators else giskard.scan(model_instance)
+            report = giskard.scan(model_instance, only=evaluators, raise_exceptions=True) if evaluators \
+                     else giskard.scan(model_instance, raise_exceptions=True)
         except Exception as e:
             raise RuntimeError(f"Error occurred during model scan: {str(e)}")
 


### PR DESCRIPTION
## Description

- Raise exceptions while running scan, so that we can print the error message if anything goes wrong. This will help the user to debug his application.
- import `giskard` as `scanner`, so that stack traces/error messages won't contain giskard anywhere.
- Support for async `model_predict` functions

## Related Issue
User was not able to see an informative error message since we we have disabled logging, and the scan function does not raise exceptions by default - we enabled them.

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested on https://colab.research.google.com/drive/1v03ANv8iJpbubUapEG8PALat1sSHzZUQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended scanning functionality now supports both synchronous and asynchronous operations for increased flexibility.

- **Enhancements**
	- Improved error handling during the scanning process to ensure smoother performance.
	- Updated documentation to clearly indicate the support for varied model execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->