### PR TITLE
Feat: Append metric to evaluate a metric on newly append dataset/rows

### DIFF
--- a/ragaai_catalyst/evaluation.py
+++ b/ragaai_catalyst/evaluation.py
@@ -358,7 +358,10 @@ class Evaluation:
         except Exception as e:
             logger.error(f"An unexpected error occurred: {e}")
 
-    def append_metrics(self, display_name):
+    def append_metric(self, display_name):
+        if not isinstance(display_name, str):
+            raise ValueError("display_name should be a string")
+        
         headers = {
             "Authorization": f"Bearer {os.getenv('RAGAAI_CATALYST_TOKEN')}",
             'X-Project-Id': str(self.project_id),

--- a/ragaai_catalyst/evaluation.py
+++ b/ragaai_catalyst/evaluation.py
@@ -358,7 +358,7 @@ class Evaluation:
         except Exception as e:
             logger.error(f"An unexpected error occurred: {e}")
 
-    def append_metric(self, display_name):
+    def append_metrics(self, display_name):
         if not isinstance(display_name, str):
             raise ValueError("display_name should be a string")
         

--- a/ragaai_catalyst/evaluation.py
+++ b/ragaai_catalyst/evaluation.py
@@ -4,6 +4,7 @@ import pandas as pd
 import io
 from .ragaai_catalyst import RagaAICatalyst
 import logging
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ class Evaluation:
         self.project_name = project_name
         self.dataset_name = dataset_name
         self.base_url = f"{RagaAICatalyst.BASE_URL}"
-        self.timeout = 10
+        self.timeout = 20
         self.jobId = None
         self.num_projects=99999
 
@@ -339,6 +340,49 @@ class Evaluation:
                 json=metric_schema_mapping,
                 timeout=self.timeout
                 )
+            if response.status_code == 400:
+                raise ValueError(response.json()["message"])
+            response.raise_for_status()
+            if response.json()["success"]:
+                print(response.json()["message"])
+                self.jobId = response.json()["data"]["jobId"]
+
+        except requests.exceptions.HTTPError as http_err:
+            logger.error(f"HTTP error occurred: {http_err}")
+        except requests.exceptions.ConnectionError as conn_err:
+            logger.error(f"Connection error occurred: {conn_err}")
+        except requests.exceptions.Timeout as timeout_err:
+            logger.error(f"Timeout error occurred: {timeout_err}")
+        except requests.exceptions.RequestException as req_err:
+            logger.error(f"An error occurred: {req_err}")
+        except Exception as e:
+            logger.error(f"An unexpected error occurred: {e}")
+
+    def append_metrics(self, display_name):
+        headers = {
+            "Authorization": f"Bearer {os.getenv('RAGAAI_CATALYST_TOKEN')}",
+            'X-Project-Id': str(self.project_id),
+            'Content-Type': 'application/json',
+        }
+
+        payload = json.dumps({
+        "datasetId": self.dataset_id,
+        "metricParams": [
+            {
+            "metricSpec": {
+                "displayName": display_name
+            }
+            }
+        ]
+        })
+        
+        try:
+            response = requests.request(
+                "POST", 
+                f'{self.base_url}/v2/llm/metric-evaluation-rerun', 
+                headers=headers, 
+                data=payload, 
+                timeout=self.timeout)
             if response.status_code == 400:
                 raise ValueError(response.json()["message"])
             response.raise_for_status()


### PR DESCRIPTION
## Description
- This update enables users to evaluate a metric with the same display name on newly appended rows or datasets, provided the metric configuration remains unchanged.

## Related Issue
- Previously, a new column had to be created each time a user wanted to evaluate the same metric on newly appended rows.
- Previously evaluated rows were also being re-evaluated, leading to redundancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the capability to record evaluation metrics with customizable display names for more descriptive tracking.
  
- **Chores**
  - Adjusted external request handling to extend wait durations, enhancing system stability when communicating with outside services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->