### PR TITLE
Fix single file zipping bug

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/utils/zip_list_of_unique_files.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/utils/zip_list_of_unique_files.py
@@ -8,6 +8,7 @@ import ast
 import importlib.util
 import json
 import ipynbname
+from copy import deepcopy
 
 from pathlib import Path
 from IPython import get_ipython
@@ -371,7 +372,8 @@ class TraceDependencyTracker:
             except Exception as e:
                 pass
         
-        for filepath in self.tracked_files:
+        curr_tracked_files = deepcopy(self.tracked_files)
+        for filepath in curr_tracked_files:
             try:
                 with open(filepath, 'r', encoding='utf-8') as file:
                     content = file.read()
@@ -447,7 +449,11 @@ class TraceDependencyTracker:
                     continue
                 try:
                     relative_path = os.path.relpath(filepath, base_path)
-                    zipf.write(filepath, relative_path)
+                    if relative_path in ['', '.']:
+                        zipf.write(filepath, os.path.basename(filepath))
+                    else:
+                        zipf.write(filepath, relative_path)
+                    
                     logger.debug(f"Added python script to zip: {relative_path}")
                 except Exception as e:
                     pass


### PR DESCRIPTION
# Pull Request Template

## Description
Fixes bugs of modification of set while iterating and single file zipping.

## Related Issue
File tracking set was getting modified while iterating and if a single file was being traced, it didn't get zipped.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file archiving reliability by processing a safe copy of tracked items to prevent interruptions during archive creation.
	- Refined file path handling so that files are archived with the correct naming, ensuring consistency when file paths are ambiguous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->