### PR TITLE
Agentic/dataset span bug

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -117,25 +117,7 @@ class UploadAgenticTraces:
                         })
                 else:
                     datasetSpans.extend(self._get_agent_dataset_spans(span, datasetSpans))
-                    # datasetSpans.append({
-                    #             "spanId": span["id"],
-                    #             "spanName": span["name"],
-                    #             "spanHash": span["hash_id"],
-                    #             "spanType": span["type"],
-                    #         })
-                    # children = span["data"]["children"]
-                    # for child in children:
-                    #     existing_span = next((s for s in datasetSpans if s["spanHash"] == child["hash_id"]), None)
-                    #     if existing_span is None:
-                    #         datasetSpans.append({
-                    #             "spanId": child["id"],
-                    #             "spanName": child["name"],
-                    #             "spanHash": child["hash_id"],
-                    #             "spanType": child["type"],
-                    #         })
             datasetSpans = [dict(t) for t in set(tuple(sorted(d.items())) for d in datasetSpans)]
-            with open("datasetSpans_new.json", "w") as f:
-                json.dump(datasetSpans, f, default=str, indent=4)
             
             return datasetSpans
         except Exception as e:

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -116,27 +116,61 @@ class UploadAgenticTraces:
                             "spanType": span["type"],
                         })
                 else:
-                    datasetSpans.append({
+                    datasetSpans.extend(self._get_agent_dataset_spans(span, datasetSpans))
+                    # datasetSpans.append({
+                    #             "spanId": span["id"],
+                    #             "spanName": span["name"],
+                    #             "spanHash": span["hash_id"],
+                    #             "spanType": span["type"],
+                    #         })
+                    # children = span["data"]["children"]
+                    # for child in children:
+                    #     existing_span = next((s for s in datasetSpans if s["spanHash"] == child["hash_id"]), None)
+                    #     if existing_span is None:
+                    #         datasetSpans.append({
+                    #             "spanId": child["id"],
+                    #             "spanName": child["name"],
+                    #             "spanHash": child["hash_id"],
+                    #             "spanType": child["type"],
+                    #         })
+            datasetSpans = [dict(t) for t in set(tuple(sorted(d.items())) for d in datasetSpans)]
+            with open("datasetSpans_new.json", "w") as f:
+                json.dump(datasetSpans, f, default=str, indent=4)
+            
+            return datasetSpans
+        except Exception as e:
+            print(f"Error while reading dataset spans: {e}")
+            return None
+
+    def _get_agent_dataset_spans(self, span, datasetSpans):
+        datasetSpans.append({
                                 "spanId": span["id"],
                                 "spanName": span["name"],
                                 "spanHash": span["hash_id"],
                                 "spanType": span["type"],
                             })
-                    children = span["data"]["children"]
-                    for child in children:
-                        existing_span = next((s for s in datasetSpans if s["spanHash"] == child["hash_id"]), None)
-                        if existing_span is None:
-                            datasetSpans.append({
-                                "spanId": child["id"],
-                                "spanName": child["name"],
-                                "spanHash": child["hash_id"],
-                                "spanType": child["type"],
-                            })
-            return datasetSpans
-        except Exception as e:
-            print(f"Error while reading dataset spans: {e}")
-            return None
-    
+        children = span["data"]["children"]
+        for child in children:
+            if child["type"] != "agent":
+                existing_span = next((s for s in datasetSpans if s["spanHash"] == child["hash_id"]), None)
+                if existing_span is None:
+                    datasetSpans.append({
+                        "spanId": child["id"],
+                        "spanName": child["name"],
+                        "spanHash": child["hash_id"],
+                        "spanType": child["type"],
+                    })
+            else:
+                datasetSpans.append({
+                            "spanId": child["id"],
+                            "spanName": child["name"],
+                            "spanHash": child["hash_id"],
+                            "spanType": child["type"],
+                        })
+                self._get_agent_dataset_spans(child, datasetSpans)
+        return datasetSpans
+        
+
     def upload_agentic_traces(self):
         try:
             presignedUrl = self._get_presigned_url()


### PR DESCRIPTION
## Description
- Retrieval of dataset spans for nested agent-type spans.

## Related Issue
- Previously, if an agent-type span contained another agent-type span, its retrieval was missed, preventing the agent/LLM from being reflected during metric evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced processing for agent-related data, ensuring accurate handling and recursive processing of nested information.

- **Refactor**
  - Optimized data workflows by clearly separating agent and non-agent elements and integrating deduplication measures for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->