### PR TITLE
Initializing task manager to upload trace in init

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/tracers/base.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/tracers/base.py
@@ -92,6 +92,8 @@ class BaseTracer:
         self._upload_tasks = []
         self._is_uploading = False
         self._upload_completed_callback = None
+        
+        ensure_uploader_running()
 
     def _get_system_info(self) -> SystemInfo:
         return self.system_monitor.get_system_info()


### PR DESCRIPTION
# Pull Request Template

## Description
Initializing task manager to upload trace in init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved system reliability by automatically activating the background uploader service during component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->