### PR TITLE
fix: increased the num_projects from 100 to 99999

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -127,7 +127,7 @@ class Tracer(AgenticTracing):
         self.upload_timeout = upload_timeout
         self.base_url = f"{RagaAICatalyst.BASE_URL}"
         self.timeout = 30
-        self.num_projects = 100
+        self.num_projects = 99999
         self.start_time = datetime.datetime.now().astimezone().isoformat()
         self.model_cost_dict = model_cost
         self.user_context = ""  # Initialize user_context to store context from add_context


### PR DESCRIPTION
## Description
- Increase the default project count limit when retrieving the project list from 100 to a significantly higher value of 99,999.

## Related Issue
- Earlier, Only 100 projects were being fetched, causing a "project not found" error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the system's capacity to process a significantly higher number of projects, enabling greater scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->