### PR TITLE
fix: Set the initial cost to zero, and used get method to retrieve model_name, cost, and latency

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -485,6 +485,7 @@ class Tracer(AgenticTracing):
             data, additional_metadata = self.langchain_tracer.stop()
 
             # Add cost if possible
+            additional_metadata["cost"] = 0.0
             if additional_metadata.get('model_name'):
                 try:
                     if self.model_custom_cost.get(additional_metadata['model_name']):
@@ -518,7 +519,6 @@ class Tracer(AgenticTracing):
 
             # Safely remove tokens and cost dictionaries if they exist
             additional_metadata.pop("tokens", None)
-            # additional_metadata.pop("cost", None)
 
             additional_metadata["model"] = additional_metadata.get("model_name", "")
             
@@ -531,9 +531,9 @@ class Tracer(AgenticTracing):
                 
             model_cost_latency_metadata = {}
             if additional_metadata:
-                model_cost_latency_metadata["model_name"] = additional_metadata["model_name"]
-                model_cost_latency_metadata["total_cost"] = additional_metadata["cost"]
-                model_cost_latency_metadata["total_latency"] = additional_metadata["latency"]
+                model_cost_latency_metadata["model_name"] = additional_metadata.get("model_name", 0)
+                model_cost_latency_metadata["total_cost"] = additional_metadata.get("cost", 0)
+                model_cost_latency_metadata["total_latency"] = additional_metadata.get("latency", 0)
                 model_cost_latency_metadata["recorded_on"] = datetime.datetime.now().astimezone().isoformat()
                 combined_metadata.update(model_cost_latency_metadata)
 


### PR DESCRIPTION
## Description
- Set the initial cost to zero (0) if the cost is not present in the traces.
- Used the get method to retrieve model_name, cost, and latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the reliability of cost data processing by ensuring default cost values are consistently applied, resulting in smoother and more robust operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->