### PR TITLE
fix: Improve span error handling in OpenInference trace exporters

### DIFF
--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -34,26 +34,30 @@ class RAGATraceExporter(SpanExporter):
 
     def export(self, spans):
         for span in spans:
-            span_json = json.loads(span.to_json())
-            trace_id = span_json.get("context").get("trace_id")
-            if trace_id is None:
-                raise Exception("Trace ID is None")
+            try:
+                span_json = json.loads(span.to_json())
+                trace_id = span_json.get("context").get("trace_id")
+                if trace_id is None:
+                    raise Exception("Trace ID is None")
 
-            if trace_id not in self.trace_spans:
-                self.trace_spans[trace_id] = list()
+                if trace_id not in self.trace_spans:
+                    self.trace_spans[trace_id] = list()
 
-            self.trace_spans[trace_id].append(span_json)
+                self.trace_spans[trace_id].append(span_json)
 
-            if span_json["parent_id"] is None:
-                trace = self.trace_spans[trace_id]
-                try:
-                    self.process_complete_trace(trace, trace_id)
-                except Exception as e:
-                    raise Exception(f"Error processing complete trace: {e}")
-                try:
-                    del self.trace_spans[trace_id]
-                except Exception as e:
-                    raise Exception(f"Error deleting trace: {e}")
+                if span_json["parent_id"] is None:
+                    trace = self.trace_spans[trace_id]
+                    try:
+                        self.process_complete_trace(trace, trace_id)
+                    except Exception as e:
+                        raise Exception(f"Error processing complete trace: {e}")
+                    try:
+                        del self.trace_spans[trace_id]
+                    except Exception as e:
+                        raise Exception(f"Error deleting trace: {e}")
+            except Exception as e:
+                logger.error(f"Error processing span: {e}")
+                continue
 
         return SpanExportResult.SUCCESS
 


### PR DESCRIPTION
## Description
- Added robust error handling in RAGATraceExporter to gracefully handle span processing failures

## Related Issue
- The exporters were failing when processing certain span types from OpenInference, particularly when dealing with tuple-formatted messages.
- The error was originating from OpenInference's internal message parsing:
  ```python
  ValueError: failed to parse messages of type <class 'tuple'>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the export process with improved error handling, ensuring that processing continues smoothly even if individual issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->