### PR TITLE
fix: fetch 99999 datasets instead of 12

### DIFF
--- a/ragaai_catalyst/dataset.py
+++ b/ragaai_catalyst/dataset.py
@@ -69,7 +69,7 @@ class Dataset:
                 "Authorization": f"Bearer {os.getenv('RAGAAI_CATALYST_TOKEN')}",
                 "X-Project-Id": str(self.project_id),
             }
-            json_data = {"size": 12, "page": "0", "projectId": str(self.project_id), "search": ""}
+            json_data = {"size": 99999, "page": "0", "projectId": str(self.project_id), "search": ""}
             try:
                 response = requests.post(
                     f"{Dataset.BASE_URL}/v2/llm/dataset",


### PR DESCRIPTION
## Description
- Changed size parameter in list_dataset method to fetch top 99999 dataset, instead of top 12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum number of records retrieved in a single data request to provide users with a more comprehensive dataset experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->