### PR TITLE
feat: max_upload_workers argument during trace initialisation 

### DIFF
--- a/ragaai_catalyst/tracers/exporters/dynamic_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/dynamic_trace_exporter.py
@@ -14,7 +14,7 @@ class DynamicTraceExporter(SpanExporter):
     certain properties to be updated dynamically during execution.
     """
     
-    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None):
+    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_uplaod_workers = 30):
         """
         Initialize the DynamicTraceExporter.
         
@@ -27,6 +27,7 @@ class DynamicTraceExporter(SpanExporter):
             user_details: User details
             base_url: Base URL for API
             post_processor: Post processing function before uploading trace
+            max_uplaod_workers: Maximum number of upload workers
         """
         self._exporter = RAGATraceExporter(
             tracer_type=tracer_type,
@@ -38,7 +39,8 @@ class DynamicTraceExporter(SpanExporter):
             base_url=base_url,
             custom_model_cost=custom_model_cost,
             timeout=timeout,
-            post_processor= post_processor
+            post_processor= post_processor,
+            max_uplaod_workers = max_uplaod_workers
         )
         
         # Store the initial values
@@ -50,6 +52,7 @@ class DynamicTraceExporter(SpanExporter):
         self._base_url = base_url
         self._custom_model_cost = custom_model_cost
         self._post_processor = post_processor
+        self._max_uplaod_workers = max_uplaod_workers
 
     
     def export(self, spans):
@@ -107,6 +110,7 @@ class DynamicTraceExporter(SpanExporter):
         self._exporter.base_url = self._base_url
         self._exporter.custom_model_cost = self._custom_model_cost
         self._exporter.post_processor = self._post_processor
+        self._exporter.max_uplaod_workers = self._max_uplaod_workers
     
     # Getter and setter methods for dynamic properties
     
@@ -165,3 +169,11 @@ class DynamicTraceExporter(SpanExporter):
     @custom_model_cost.setter
     def custom_model_cost(self, value):
         self._custom_model_cost = value
+    
+    @property
+    def max_uplaod_workers(self):
+        return self._max_uplaod_workers
+    
+    @max_uplaod_workers.setter
+    def max_uplaod_workers(self, value):
+        self._max_uplaod_workers = value

--- a/ragaai_catalyst/tracers/exporters/dynamic_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/dynamic_trace_exporter.py
@@ -14,7 +14,7 @@ class DynamicTraceExporter(SpanExporter):
     certain properties to be updated dynamically during execution.
     """
     
-    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_uplaod_workers = 30):
+    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_upload_workers = 30):
         """
         Initialize the DynamicTraceExporter.
         
@@ -27,7 +27,7 @@ class DynamicTraceExporter(SpanExporter):
             user_details: User details
             base_url: Base URL for API
             post_processor: Post processing function before uploading trace
-            max_uplaod_workers: Maximum number of upload workers
+            max_upload_workers: Maximum number of upload workers
         """
         self._exporter = RAGATraceExporter(
             tracer_type=tracer_type,
@@ -40,7 +40,7 @@ class DynamicTraceExporter(SpanExporter):
             custom_model_cost=custom_model_cost,
             timeout=timeout,
             post_processor= post_processor,
-            max_uplaod_workers = max_uplaod_workers
+            max_upload_workers = max_upload_workers
         )
         
         # Store the initial values
@@ -52,7 +52,7 @@ class DynamicTraceExporter(SpanExporter):
         self._base_url = base_url
         self._custom_model_cost = custom_model_cost
         self._post_processor = post_processor
-        self._max_uplaod_workers = max_uplaod_workers
+        self._max_upload_workers = max_upload_workers
 
     
     def export(self, spans):
@@ -110,7 +110,7 @@ class DynamicTraceExporter(SpanExporter):
         self._exporter.base_url = self._base_url
         self._exporter.custom_model_cost = self._custom_model_cost
         self._exporter.post_processor = self._post_processor
-        self._exporter.max_uplaod_workers = self._max_uplaod_workers
+        self._exporter.max_upload_workers = self._max_upload_workers
     
     # Getter and setter methods for dynamic properties
     
@@ -171,9 +171,9 @@ class DynamicTraceExporter(SpanExporter):
         self._custom_model_cost = value
     
     @property
-    def max_uplaod_workers(self):
-        return self._max_uplaod_workers
+    def max_upload_workers(self):
+        return self._max_upload_workers
     
-    @max_uplaod_workers.setter
-    def max_uplaod_workers(self, value):
-        self._max_uplaod_workers = value
+    @max_upload_workers.setter
+    def max_upload_workers(self, value):
+        self._max_upload_workers = value

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -26,7 +26,7 @@ logging_level = (
 
 
 class RAGATraceExporter(SpanExporter):
-    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_uplaod_workers = 30):
+    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_upload_workers = 30):
         self.trace_spans = dict()
         self.tmp_dir = tempfile.gettempdir()
         self.tracer_type = tracer_type
@@ -40,7 +40,7 @@ class RAGATraceExporter(SpanExporter):
         self.system_monitor = SystemMonitor(dataset_name)
         self.timeout = timeout
         self.post_processor = post_processor
-        self.max_uplaod_workers = max_uplaod_workers
+        self.max_upload_workers = max_upload_workers
 
     def export(self, spans):
         for span in spans:
@@ -190,7 +190,7 @@ class RAGATraceExporter(SpanExporter):
                 json.dump(ragaai_trace, f, indent=2)
             
             # Create a ThreadPoolExecutor with max_workers=30
-            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_uplaod_workers) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_upload_workers) as executor:
                 # Create a partial function with all the necessary arguments
                 upload_func = partial(
                     UploadTraces(

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -26,7 +26,7 @@ logging_level = (
 
 
 class RAGATraceExporter(SpanExporter):
-    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None):
+    def __init__(self, tracer_type, files_to_zip, project_name, project_id, dataset_name, user_details, base_url, custom_model_cost, timeout=120, post_processor = None, max_uplaod_workers = 30):
         self.trace_spans = dict()
         self.tmp_dir = tempfile.gettempdir()
         self.tracer_type = tracer_type
@@ -40,6 +40,7 @@ class RAGATraceExporter(SpanExporter):
         self.system_monitor = SystemMonitor(dataset_name)
         self.timeout = timeout
         self.post_processor = post_processor
+        self.max_uplaod_workers = max_uplaod_workers
 
     def export(self, spans):
         for span in spans:
@@ -189,7 +190,7 @@ class RAGATraceExporter(SpanExporter):
                 json.dump(ragaai_trace, f, indent=2)
             
             # Create a ThreadPoolExecutor with max_workers=30
-            with concurrent.futures.ThreadPoolExecutor(max_workers=30) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_uplaod_workers) as executor:
                 # Create a partial function with all the necessary arguments
                 upload_func = partial(
                     UploadTraces(

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -59,6 +59,7 @@ class Tracer(AgenticTracing):
         },
         interval_time=2,
         # auto_instrumentation=True/False  # to control automatic instrumentation of everything
+        max_uplaod_workers=30
 
     ):
         """
@@ -141,6 +142,7 @@ class Tracer(AgenticTracing):
         self.user_context = ""  # Initialize user_context to store context from add_context
         self.file_tracker = TrackName()
         self.post_processor = None
+        self.max_uplaod_workers = max_uplaod_workers
         
         try:
             response = requests.get(
@@ -763,7 +765,8 @@ class Tracer(AgenticTracing):
             base_url=self.base_url,
             custom_model_cost=self.model_custom_cost,
             timeout = self.timeout,
-            post_processor= self.post_processor
+            post_processor= self.post_processor,
+            max_uplaod_workers = self.max_uplaod_workers
         )
         
         # Set up tracer provider

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -59,7 +59,7 @@ class Tracer(AgenticTracing):
         },
         interval_time=2,
         # auto_instrumentation=True/False  # to control automatic instrumentation of everything
-        max_uplaod_workers=30
+        max_upload_workers=30
 
     ):
         """
@@ -142,7 +142,7 @@ class Tracer(AgenticTracing):
         self.user_context = ""  # Initialize user_context to store context from add_context
         self.file_tracker = TrackName()
         self.post_processor = None
-        self.max_uplaod_workers = max_uplaod_workers
+        self.max_upload_workers = max_upload_workers
         
         try:
             response = requests.get(
@@ -766,7 +766,7 @@ class Tracer(AgenticTracing):
             custom_model_cost=self.model_custom_cost,
             timeout = self.timeout,
             post_processor= self.post_processor,
-            max_uplaod_workers = self.max_uplaod_workers
+            max_upload_workers = self.max_upload_workers
         )
         
         # Set up tracer provider


### PR DESCRIPTION
- Add support to define max_uplaod_workers in tracer initialisation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to configure the maximum number of concurrent upload workers for trace exporting, allowing users to adjust upload parallelism for improved performance or resource management. The default value is set to 30 but can now be customized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->