### PR TITLE
Replaced 'Human:" str by empty string in prompt extraction

### DIFF
--- a/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
+++ b/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
@@ -44,7 +44,7 @@ def rag_trace_json_converter(input_trace, custom_model_cost, trace_id, user_deta
                                             if isinstance(message, str):
                                                 human_index = message.find("Human:")
                                                 if human_index != -1:
-                                                    human_message = message[human_index:]
+                                                    human_message = message[human_index+6:]
                                                     break
                                         return human_message if human_message else value
                                 except Exception as e:

--- a/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
+++ b/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
@@ -44,7 +44,7 @@ def rag_trace_json_converter(input_trace, custom_model_cost, trace_id, user_deta
                                             if isinstance(message, str):
                                                 human_index = message.find("Human:")
                                                 if human_index != -1:
-                                                    human_message = message[human_index+6:]
+                                                    human_message = message[human_index:].replace("Human:", "")
                                                     break
                                         return human_message if human_message else value
                                 except Exception as e:


### PR DESCRIPTION
- Replace 'Human:' str in prompt extraction for VertextAI model calss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt extraction by removing the "Human:" label from messages, resulting in cleaner and more accurate prompts for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->