### PR TITLE
Add 'error' key in RAG traces

### DIFF
--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -258,12 +258,18 @@ class RAGATraceExporter(SpanExporter):
     
     def prepare_rag_trace(self, spans, trace_id):
         try:            
+            # with open(os.path.join(os.getcwd(), "traces_with_error.json"), "w") as f:
+            #     json.dump(spans, f, indent=4)
             ragaai_trace, additional_metadata = rag_trace_json_converter(spans, self.custom_model_cost, trace_id, self.user_details, self.tracer_type,self.user_context)
             ragaai_trace["metadata"]["recorded_on"] = datetime.datetime.now().astimezone().isoformat()
             ragaai_trace["metadata"]["log_source"] = "langchain_tracer"
+            # with open(os.path.join(os.getcwd(), "traces_with_error_b4_callback.json"), "w") as f:
+            #     json.dump(ragaai_trace, f, indent=4)
 
             if True:
                 converted_ragaai_trace = convert_langchain_callbacks_output(ragaai_trace, self.project_name, ragaai_trace["metadata"], ragaai_trace["pipeline"])
+                with open(os.path.join(os.getcwd(), "traces_with_error_aftr_callback.json"), "w") as f:
+                    json.dump(converted_ragaai_trace, f, indent=4)
             else:
                 converted_ragaai_trace = ragaai_trace
             

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -258,18 +258,12 @@ class RAGATraceExporter(SpanExporter):
     
     def prepare_rag_trace(self, spans, trace_id):
         try:            
-            # with open(os.path.join(os.getcwd(), "traces_with_error.json"), "w") as f:
-            #     json.dump(spans, f, indent=4)
             ragaai_trace, additional_metadata = rag_trace_json_converter(spans, self.custom_model_cost, trace_id, self.user_details, self.tracer_type,self.user_context)
             ragaai_trace["metadata"]["recorded_on"] = datetime.datetime.now().astimezone().isoformat()
             ragaai_trace["metadata"]["log_source"] = "langchain_tracer"
-            # with open(os.path.join(os.getcwd(), "traces_with_error_b4_callback.json"), "w") as f:
-            #     json.dump(ragaai_trace, f, indent=4)
 
             if True:
                 converted_ragaai_trace = convert_langchain_callbacks_output(ragaai_trace, self.project_name, ragaai_trace["metadata"], ragaai_trace["pipeline"])
-                with open(os.path.join(os.getcwd(), "traces_with_error_aftr_callback.json"), "w") as f:
-                    json.dump(converted_ragaai_trace, f, indent=4)
             else:
                 converted_ragaai_trace = ragaai_trace
             

--- a/ragaai_catalyst/tracers/upload_traces.py
+++ b/ragaai_catalyst/tracers/upload_traces.py
@@ -45,6 +45,9 @@ class UploadTraces:
                 else:
                     SCHEMA_MAPPING_NEW[key] = {"columnType": key, "parentColumn": "response"}
 
+        if "error" in additional_metadata_keys and additional_metadata_keys["error"]:
+            SCHEMA_MAPPING_NEW["error"] = {"columnType": "metadata"}
+
         if additional_pipeline_keys:
             for key in additional_pipeline_keys:
                 SCHEMA_MAPPING_NEW[key] = {"columnType": "pipeline"}

--- a/ragaai_catalyst/tracers/utils/convert_langchain_callbacks_output.py
+++ b/ragaai_catalyst/tracers/utils/convert_langchain_callbacks_output.py
@@ -58,4 +58,5 @@ def convert_langchain_callbacks_output(result, project_name="", metadata="", pip
 
     initial_struc[0]["traces"] = traces_data
 
+    initial_struc[0]["error"] = result["error"]
     return initial_struc

--- a/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
+++ b/ragaai_catalyst/tracers/utils/rag_trace_json_converter.py
@@ -212,6 +212,9 @@ def rag_trace_json_converter(input_trace, custom_model_cost, trace_id, user_deta
     
     trace_aggregate["metadata"] = user_details.get("trace_user_detail", {}).get("metadata")
     trace_aggregate["metadata"].update(additional_metadata)
+    trace_aggregate["metadata"]["error"] = f"{error}"
+    additional_metadata["error"] = error if error else None
+
     additional_metadata.pop("total_cost")
     additional_metadata.pop("total_latency")
     return trace_aggregate, additional_metadata


### PR DESCRIPTION
## Description
- Added error key in final RAG traces. 

## Dashboard url:
https://llm-dev5.ragaai.ai/projects/evaluation?projectId=402&datasetId=4277
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added error details to trace outputs, allowing users to view error information associated with traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->