### PR TITLE
Rag application tracing masking 

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
@@ -19,6 +19,7 @@ import glob
 from logging.handlers import RotatingFileHandler
 import concurrent.futures
 from typing import Dict, Any, Optional
+import traceback
 
 # Set up logging
 log_dir = os.path.join(tempfile.gettempdir(), "ragaai_logs")
@@ -157,7 +158,8 @@ def process_upload(task_id: str, filepath: str, hash_id: str, zip_path: str,
                 )
                 logger.info(f"Trace metrics uploaded: {response}")
             except Exception as e:
-                logger.error(f"Error uploading trace metrics: {e}")
+                logger.error(f"Error uploading trace trace uploader metrics: {e}")
+                print("traceback_uploader ",traceback.format_exc())
                 # Continue with other uploads
         else:
             logger.warning(f"Trace file {filepath} not found, skipping metrics upload")

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
@@ -19,7 +19,6 @@ import glob
 from logging.handlers import RotatingFileHandler
 import concurrent.futures
 from typing import Dict, Any, Optional
-import traceback
 
 # Set up logging
 log_dir = os.path.join(tempfile.gettempdir(), "ragaai_logs")
@@ -159,7 +158,6 @@ def process_upload(task_id: str, filepath: str, hash_id: str, zip_path: str,
                 logger.info(f"Trace metrics uploaded: {response}")
             except Exception as e:
                 logger.error(f"Error uploading trace trace uploader metrics: {e}")
-                print("traceback_uploader ",traceback.format_exc())
                 # Continue with other uploads
         else:
             logger.warning(f"Trace file {filepath} not found, skipping metrics upload")

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -216,12 +216,7 @@ class RAGATraceExporter(SpanExporter):
             logger.info(f"Trace file saved at {trace_file_path}")
             if self.post_processor!=None:
                 trace_file_path = self.post_processor(trace_file_path)
-                dir_name, original_filename = os.path.split(trace_file_path)
-                new_filename = f"postprocessing_{original_filename}"
-                trace_file_path = os.path.join(dir_name, new_filename)
-            with open(trace_file_path, 'w') as f:
-                json.dump(ragaai_trace, f, indent=2)
-            logger.info(f"After post processing Trace file saved at {trace_file_path}")
+                logger.info(f"After post processing Trace file saved at {trace_file_path}")
 
             # Create a ThreadPoolExecutor with max_workers=30
             with concurrent.futures.ThreadPoolExecutor(max_workers=self.max_upload_workers) as executor:

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -18,7 +18,6 @@ import logging
 import asyncio
 import concurrent.futures
 from functools import partial
-import traceback
 
 logger = logging.getLogger("RagaAICatalyst")
 logging_level = (

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -434,13 +434,13 @@ class Tracer(AgenticTracing):
                 masked_traces = []
                 for item in data:
                     if isinstance(item, dict) and 'traces' in item:
-                        masked = recursive_mask_values(item['traces'])
-                        masked_traces.extend(masked if isinstance(masked, list) else [masked])
+                        item['traces'] = recursive_mask_values(item['traces'])
+                        masked_traces.append(item)
                 data = masked_traces
-            
-            # Create new filename with 'processed_' prefix in /var/tmp/
+            # Create new filename with 'processed_' prefix 
             new_filename = f"processed_{original_path.name}"
-            final_trace_json_path = Path("/var/tmp") / new_filename
+            dir_name, original_filename = os.path.split(original_trace_json_path)
+            final_trace_json_path = Path(dir_name) / new_filename
             
             # Write modified data to the new file
             with open(final_trace_json_path, 'w') as f:

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -427,8 +427,16 @@ class Tracer(AgenticTracing):
             with open(original_path, 'r') as f:
                 data = json.load(f)
             
-            # Apply masking only to data['data']
-            data['data'] = recursive_mask_values(data['data'])
+            # Apply masking only to data['data'] or in case of langchain rag apply on 'traces' field of each element
+            if 'data' in data:
+                data['data'] = recursive_mask_values(data['data'])
+            elif isinstance(data,list):
+                masked_traces = []
+                for item in data:
+                    if isinstance(item, dict) and 'traces' in item:
+                        masked = recursive_mask_values(item['traces'])
+                        masked_traces.extend(masked if isinstance(masked, list) else [masked])
+                data = masked_traces
             
             # Create new filename with 'processed_' prefix in /var/tmp/
             new_filename = f"processed_{original_path.name}"


### PR DESCRIPTION
Enabled Trace masking feature for simple Rag Application for Langchain.
This should also take care of llamaindex and future format for tracing.

Support for fields "data" and "traces" provided.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced post-processing support for trace files, allowing masking functions to be applied to additional trace data structures.
- **Bug Fixes**
  - Updated error log message during trace metrics upload for clarity.
- **Refactor**
  - Updated file saving location for processed trace files to match the original file’s directory.
  - Improved consistency in applying post-processing functions during asynchronous trace uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->