### PR TITLE
fix: pop 'error' key from schema mapping mapped to response column

### DIFF
--- a/ragaai_catalyst/tracers/upload_traces.py
+++ b/ragaai_catalyst/tracers/upload_traces.py
@@ -46,6 +46,7 @@ class UploadTraces:
                     SCHEMA_MAPPING_NEW[key] = {"columnType": key, "parentColumn": "response"}
 
         if "error" in additional_metadata_keys and additional_metadata_keys["error"]:
+            SCHEMA_MAPPING_NEW.pop("error", None)
             SCHEMA_MAPPING_NEW["error"] = {"columnType": "metadata"}
 
         if additional_pipeline_keys:


### PR DESCRIPTION
## Description
- pop the 'error' key from schema mapping mapped to response column resulting in incorrect schema mapping. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of error metadata to ensure accurate updates when error information is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->