### PR TITLE
fix(presigned-url): prefer POST, fallback to GET for presigned-URL creation

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -43,14 +43,15 @@ class UploadAgenticTraces:
         try:
             start_time = time.time()
             endpoint = f"{self.base_url}/v1/llm/presigned-url"
-            response = requests.request("GET", 
+            # Changed to POST from GET
+            response = requests.request("POST", 
                                         endpoint, 
                                         headers=headers, 
                                         data=payload,
                                         timeout=self.timeout)
             elapsed_ms = (time.time() - start_time) * 1000
             logger.debug(
-                f"API Call: [GET] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
+                f"API Call: [POST] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
             
             if response.status_code == 200:
                 presignedURLs = response.json()["data"]["presignedUrls"][0]

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -57,9 +57,26 @@ class UploadAgenticTraces:
                 presignedURLs = response.json()["data"]["presignedUrls"][0]
                 presignedurl = self.update_presigned_url(presignedURLs,self.base_url)
                 return presignedurl
+            else:
+                # If POST fails, try GET
+                response = requests.request("GET", 
+                                        endpoint, 
+                                        headers=headers, 
+                                        data=payload,
+                                        timeout=self.timeout)
+                elapsed_ms = (time.time() - start_time) * 1000
+                logger.debug(
+                    f"API Call: [GET] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
+                if response.status_code == 200:
+                    presignedURLs = response.json()["data"]["presignedUrls"][0]
+                    presignedurl = self.update_presigned_url(presignedURLs,self.base_url)
+                    return presignedurl
+
+                logger.error(f"Error while getting presigned url: {response.json()['message']}")
+                return None
             
         except requests.exceptions.RequestException as e:
-            print(f"Error while getting presigned url: {e}")
+            logger.error(f"Error while getting presigned url: {e}")
             return None
         
     def update_presigned_url(self, presigned_url, base_url):

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
@@ -82,21 +82,23 @@ def _fetch_presigned_url(project_name, dataset_name, base_url=None, timeout=120)
     try:
         url_base = base_url if base_url is not None else RagaAICatalyst.BASE_URL
         start_time = time.time()
+        # Changed to POST from GET
         endpoint = f"{url_base}/v1/llm/presigned-url"
-        response = requests.request("GET", 
+        response = requests.request("POST", 
                                     endpoint, 
                                     headers=headers, 
                                     data=payload,
                                     timeout=timeout)
         elapsed_ms = (time.time() - start_time) * 1000
         logger.debug(
-            f"API Call: [GET] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
+            f"API Call: [POST] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
 
         if response.status_code == 200:
             presigned_url = response.json()["data"]["presignedUrls"][0]
             presigned_url = update_presigned_url(presigned_url,url_base)
             return presigned_url
         else:
+            logger.error(f"Failed to fetch code hashes: {response.json()['message']}")
             raise Exception(f"Failed to fetch code hashes: {response.json()['message']}")
     except requests.exceptions.RequestException as e:
         logger.error(f"Failed to list datasets: {e}")

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_code.py
@@ -98,6 +98,20 @@ def _fetch_presigned_url(project_name, dataset_name, base_url=None, timeout=120)
             presigned_url = update_presigned_url(presigned_url,url_base)
             return presigned_url
         else:
+            # If POST fails, try GET
+            response = requests.request("GET", 
+                                    endpoint, 
+                                    headers=headers, 
+                                    data=payload,
+                                    timeout=timeout)
+            elapsed_ms = (time.time() - start_time) * 1000
+            logger.debug(
+                f"API Call: [GET] {endpoint} | Status: {response.status_code} | Time: {elapsed_ms:.2f}ms")
+            if response.status_code == 200:
+                presigned_url = response.json()["data"]["presignedUrls"][0]
+                presigned_url = update_presigned_url(presigned_url,url_base)
+                return presigned_url
+
             logger.error(f"Failed to fetch code hashes: {response.json()['message']}")
             raise Exception(f"Failed to fetch code hashes: {response.json()['message']}")
     except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Load balancers may truncate request bodies on GET endpoints and break presigned-url generation calls. First attempt a POST-based presigned-URL request; if it fails, fall back to GET.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when obtaining presigned URLs by switching the initial request method from GET to POST, with an automatic fallback to GET if POST fails.
  - Enhanced error handling and logging for failed requests, providing clearer feedback when issues occur during upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->