### PR TITLE
Bug/set external

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -535,11 +535,18 @@ class Tracer(AgenticTracing):
             'max_upload_workers': self.max_upload_workers
         }
 
+        # Save the model_custom_cost before reinitialization
+        saved_model_custom_cost = self.model_custom_cost.copy()
+
         # Reinitialize self with new external_id and stored parameters
         self.__init__(
             external_id=external_id,
             **current_params
         )
+        
+        # Restore the model_custom_cost after reinitialization
+        self.model_custom_cost = saved_model_custom_cost
+        self.dynamic_exporter.custom_model_cost = self.model_custom_cost
 
     
 

--- a/ragaai_catalyst/tracers/upload_traces.py
+++ b/ragaai_catalyst/tracers/upload_traces.py
@@ -38,7 +38,7 @@ class UploadTraces:
             "total_cost": {"columnType": "metadata", "dataType": "numerical"},
             "total_latency": {"columnType": "metadata", "dataType": "numerical"},
             "error": {"columnType": "metadata"},
-            "external_id": {"columnType": "externalId"}
+            "externalId": {"columnType": "externalId"}
         }
 
         if additional_metadata_keys:

--- a/ragaai_catalyst/tracers/upload_traces.py
+++ b/ragaai_catalyst/tracers/upload_traces.py
@@ -37,7 +37,8 @@ class UploadTraces:
             "model_name": {"columnType": "metadata"},
             "total_cost": {"columnType": "metadata", "dataType": "numerical"},
             "total_latency": {"columnType": "metadata", "dataType": "numerical"},
-            "error": {"columnType": "metadata"}
+            "error": {"columnType": "metadata"},
+            "external_id": {"columnType": "externalId"}
         }
 
         if additional_metadata_keys:


### PR DESCRIPTION
## Description
- Restored custom model cost values when `tracer.set_external_id` is called, as tracer was getting re-initialised with {} model cost values
- Added externalId in schema mapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where custom model cost settings were not retained after updating the external ID, ensuring these settings persist across changes.
- **New Features**
  - Added support for an "externalId" field in dataset schemas when uploading traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->