### PR TITLE
set_model_cost to no-op function

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -365,20 +365,8 @@ class Tracer(AgenticTracing):
                 "output_cost_per_million_token": 2.40
             })
         """
-        if not isinstance(cost_config, dict):
-            logger.error("cost_config must be a dictionary")
-
-        required_keys = {"model_name", "input_cost_per_million_token", "output_cost_per_million_token"}
-        if not all(key in cost_config for key in required_keys):
-            logger.error(f"cost_config must contain all required keys: {required_keys}")
-
-        model_name = cost_config["model_name"]
-        self.model_custom_cost[model_name] = {
-            "input_cost_per_token": float(cost_config["input_cost_per_million_token"])/ 1000000,
-            "output_cost_per_token": float(cost_config["output_cost_per_million_token"]) /1000000
-        }
-        self.dynamic_exporter.custom_model_cost = self.model_custom_cost
-        logger.info(f"Updated custom model cost for {model_name}: {self.model_custom_cost[model_name]}")
+        # No-op function - doesn't perform any operation
+        pass
         
 
     def register_masking_function(self, masking_func):

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -365,8 +365,21 @@ class Tracer(AgenticTracing):
                 "output_cost_per_million_token": 2.40
             })
         """
-        # No-op function - doesn't perform any operation
-        pass
+        # if not isinstance(cost_config, dict):
+        #     logger.error("cost_config must be a dictionary")
+
+        # required_keys = {"model_name", "input_cost_per_million_token", "output_cost_per_million_token"}
+        # if not all(key in cost_config for key in required_keys):
+        #     logger.error(f"cost_config must contain all required keys: {required_keys}")
+
+        # model_name = cost_config["model_name"]
+        # self.model_custom_cost[model_name] = {
+        #     "input_cost_per_token": float(cost_config["input_cost_per_million_token"])/ 1000000,
+        #     "output_cost_per_token": float(cost_config["output_cost_per_million_token"]) /1000000
+        # }
+        # self.dynamic_exporter.custom_model_cost = self.model_custom_cost
+        # logger.info(f"Updated custom model cost for {model_name}: {self.model_custom_cost[model_name]}")
+        return None
         
 
     def register_masking_function(self, masking_func):


### PR DESCRIPTION
## Description

- Converts the tracer.set_model_cost method to a no-op function, as model cost setting is handled at the Backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Disabled the ability to set custom model cost values; the related method now performs no action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->