### PR TITLE
refactor: add deprecated message in set_model_cost

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -365,6 +365,8 @@ class Tracer(AgenticTracing):
                 "output_cost_per_million_token": 2.40
             })
         """
+        logger.info("DEPRECATED: The set_model_cost method is deprecated and will be removed in a future version. Custom model costs can now be configured directly through the RagaAI Catalyst Platform")
+        print("DEPRECATED: The set_model_cost method is deprecated and will be removed in a future version. Custom model costs can now be configured directly through the RagaAI Catalyst Platform")
         # if not isinstance(cost_config, dict):
         #     logger.error("cost_config must be a dictionary")
 


### PR DESCRIPTION
## Description

- Add deprecated warning message in set_model_cost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added deprecation warnings to the model cost configuration method, which is now disabled and will be removed in a future version. Users are advised to configure custom model costs directly through the RagaAI Catalyst Platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->