### PR TITLE
exclude trace_id, span_id and meme_type from masking

### DIFF
--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -418,7 +418,8 @@ class Tracer(AgenticTracing):
                         'telemetry.sdk.language','service.name', 'llm.model_name',
                         'llm.invocation_parameters', 'metadata', 'openinference.span.kind',
                         'llm.token_count.prompt', 'llm.token_count.completion', 'llm.token_count.total',
-                        "input_cost", "output_cost", "total_cost", "status_code"
+                        "input_cost", "output_cost", "total_cost", "status_code", "output.mime_type",
+                        "span_id", "trace_id"
                     }
                     # Apply masking only if the key is NOT in the excluded list
                     if parent_key and parent_key.lower() not in excluded_keys:


### PR DESCRIPTION
## Description

- Exclude span_id, trace_id and meme_type from masking 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved masking of trace data by ensuring values for "output.mime_type", "span_id", and "trace_id" are preserved and not masked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->