### PR TITLE
bug-fix: calculate cost for only llm spans

### DIFF
--- a/ragaai_catalyst/tracers/utils/trace_json_converter.py
+++ b/ragaai_catalyst/tracers/utils/trace_json_converter.py
@@ -189,7 +189,7 @@ def convert_json_format(
                 model_name = next((name for name in reversed(model_names) if name), "")
                 if not model_name and span["attributes"].get("openinference.span.kind")=="LLM":
                     model_name = json.loads(span["attributes"].get("metadata", "")).get("ls_model_name", "")
-                if model_name:
+                if model_name and span["attributes"].get("openinference.span.kind") == "LLM":
                     try:
                         model_costs = get_model_cost()
                         span_cost = calculate_llm_cost(


### PR DESCRIPTION
added condition in trace_json_converter.py while calculating model_cost

if model_name and span["attributes"].get("openinference.span.kind") == "LLM"
          


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of LLM cost calculations by ensuring costs are only computed for spans explicitly marked as LLM and with a valid model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->