### PR TITLE
correcting csv file reader error for non-utf characters

### DIFF
--- a/ragaai_catalyst/synthetic_data_generation.py
+++ b/ragaai_catalyst/synthetic_data_generation.py
@@ -517,7 +517,7 @@ class SyntheticDataGeneration:
             str: The extracted text content from the CSV, with each row joined and separated by newlines.
         """
         text = ""
-        with open(file_path, 'r', encoding='utf-8') as file:
+        with open(file_path, 'r', encoding='utf-8', errors="ignore") as file:
             csv_reader = csv.reader(file)
             for row in csv_reader:
                 text += " ".join(row) + "\n"


### PR DESCRIPTION
# Pull Request Template

## Description
Unable to read non-utf-8 characters

## Related Issue


## Type of Change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested with the csv file on which error was reported



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved CSV file handling to prevent errors when reading files with invalid UTF-8 characters. Files with encoding issues will now be read successfully, ignoring problematic characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->