### PR TITLE
Fix: Resolve external_id concurrency issues in multi-threaded tracing

### DIFF
--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -68,6 +68,8 @@ class RAGATraceExporter(SpanExporter):
             user_gt: Optional[str] = None,
             external_id: Optional[str] = None
     ):
+        # Buffer spans by (external_id, trace_id) to ensure one external_id per processed trace
+        # Structure: { (external_id, trace_id): [span_json, ...] }
         self.trace_spans = dict()
         # Use custom trace directory if environment variable is set, otherwise use temp directory
         custom_dir = os.getenv("RAGAAI_TRACE_DIR")
@@ -109,22 +111,37 @@ class RAGATraceExporter(SpanExporter):
                 if trace_id is None:
                     logger.error("Trace ID is None")
 
-                if trace_id not in self.trace_spans:
-                    self.trace_spans[trace_id] = list()
+                # Determine external_id from span attributes (may be None)
+                external_id = None
+                try:
+                    external_id = span_json.get("attributes", {}).get("ragaai.external_id", None)
+                except Exception:
+                    external_id = None
+
+                # Compose composite key: (external_id, trace_id)
+                trace_key = (external_id, trace_id)
+
+                # Initialize buffer
+                if trace_key not in self.trace_spans:
+                    self.trace_spans[trace_key] = list()
 
                 if span_json.get("attributes").get("openinference.span.kind", None) is None:
                     span_json["attributes"]["openinference.span.kind"] = "UNKNOWN"
 
-                self.trace_spans[trace_id].append(span_json)
+                # Append to the external_id-specific group
+                self.trace_spans[trace_key].append(span_json)
 
+                # If root span arrives, process only the group for its external_id
                 if span_json["parent_id"] is None:
-                    trace = self.trace_spans[trace_id]
+                    trace_group = self.trace_spans.get(trace_key, [])
                     try:
-                        self.process_complete_trace(trace, trace_id)
+                        self.process_complete_trace(trace_group, trace_id, external_id)
                     except Exception as e:
                         logger.error(f"Error processing complete trace: {e}")
                     try:
-                        del self.trace_spans[trace_id]
+                        # Remove processed group
+                        if trace_key in self.trace_spans:
+                            del self.trace_spans[trace_key]
                     except Exception as e:
                         logger.error(f"Error deleting trace: {e}")
             except Exception as e:
@@ -136,14 +153,16 @@ class RAGATraceExporter(SpanExporter):
     def shutdown(self):
         # Process any remaining traces during shutdown
         logger.debug("Reached shutdown of exporter")
-        for trace_id, spans in self.trace_spans.items():
-            self.process_complete_trace(spans, trace_id)
+        for trace_key, spans in self.trace_spans.items():
+            # trace_key = (external_id, trace_id)
+            external_id, trace_id = trace_key
+            self.process_complete_trace(spans, trace_id, external_id)
         self.trace_spans.clear()
 
-    def process_complete_trace(self, spans, trace_id):
+    def process_complete_trace(self, spans, trace_id, external_id):
         # Convert the trace to ragaai trace format
         try:
-            ragaai_trace_details = self.prepare_trace(spans, trace_id)
+            ragaai_trace_details = self.prepare_trace(spans, trace_id, external_id)
         except Exception as e:
             print(f"Error converting trace {trace_id}: {e}")
             return  # Exit early if conversion fails
@@ -161,11 +180,18 @@ class RAGATraceExporter(SpanExporter):
         except Exception as e:
             print(f"Error uploading trace {trace_id}: {e}")
 
-    def prepare_trace(self, spans, trace_id):
+    def prepare_trace(self, spans, trace_id, external_id):
         try:
             try:
-                ragaai_trace = convert_json_format(spans, self.custom_model_cost, self.user_context, self.user_gt,
-                                                   self.external_id)
+                # Prefer the group's external_id when present
+                grouped_external_id = external_id if external_id is not None else self.external_id
+                ragaai_trace = convert_json_format(
+                    spans,
+                    self.custom_model_cost,
+                    self.user_context,
+                    self.user_gt,
+                    grouped_external_id,
+                )
             except Exception as e:
                 print(f"Error in convert_json_format function: {trace_id}: {e}")
                 return None

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -28,24 +28,34 @@ from ragaai_catalyst.tracers.agentic_tracing.utils.file_name_tracker import Trac
 from opentelemetry import context
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import SpanProcessor as OtelSpanProcessor
+import contextvars
 
 logger = logging.getLogger(__name__)
+
+# Context-local external_id to avoid cross-thread/task leakage
+_RAGAAI_EXTERNAL_ID_CTX: contextvars.ContextVar = contextvars.ContextVar(
+    "ragaai_external_id_ctx",
+    default=None,
+)
 logging_level = (
     logger.setLevel(logging.DEBUG) if os.getenv("DEBUG") == "1" else logging.INFO
 )
 
 class _ExternalIdSpanProcessor(OtelSpanProcessor):
     """Span processor that stamps ragaai.external_id onto spans at start."""
-    def __init__(self, external_id_getter):
+    def __init__(self, external_id_getter=None):
+        # external_id_getter kept for backward compat, prefer contextvar
         self._external_id_getter = external_id_getter
 
     def on_start(self, span, parent_context):
         try:
-            external_id = None
-            try:
-                external_id = self._external_id_getter()
-            except Exception:
-                external_id = None
+            # Prefer context-local external_id
+            external_id = _RAGAAI_EXTERNAL_ID_CTX.get()
+            if external_id is None and self._external_id_getter is not None:
+                try:
+                    external_id = self._external_id_getter()
+                except Exception:
+                    external_id = None
             if external_id:
                 span.set_attribute("ragaai.external_id", str(external_id))
         except Exception:
@@ -510,6 +520,11 @@ class Tracer(AgenticTracing):
         Args:
             external_id (str): The new external_id to set
         """
+        # Set context-local external_id for concurrent safety
+        try:
+            _RAGAAI_EXTERNAL_ID_CTX.set(external_id)
+        except Exception:
+            pass
         # Tag current span to ensure per-trace correctness in concurrent scenarios
         try:
             span = otel_trace.get_current_span()
@@ -662,7 +677,7 @@ class Tracer(AgenticTracing):
         # Add processor to stamp external_id on all spans at start
         try:
             tracer_provider.add_span_processor(
-                _ExternalIdSpanProcessor(lambda: getattr(self.dynamic_exporter, "external_id", None))
+                _ExternalIdSpanProcessor()
             )
         except Exception as e:
             logger.debug(f"Failed to add ExternalId span processor: {e}")

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -25,11 +25,40 @@ from http.client import RemoteDisconnected
 from ragaai_catalyst.tracers.agentic_tracing import AgenticTracing
 from ragaai_catalyst.tracers.exporters.ragaai_trace_exporter import RAGATraceExporter
 from ragaai_catalyst.tracers.agentic_tracing.utils.file_name_tracker import TrackName
+from opentelemetry import context
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import SpanProcessor as OtelSpanProcessor
 
 logger = logging.getLogger(__name__)
 logging_level = (
     logger.setLevel(logging.DEBUG) if os.getenv("DEBUG") == "1" else logging.INFO
 )
+
+class _ExternalIdSpanProcessor(OtelSpanProcessor):
+    """Span processor that stamps ragaai.external_id onto spans at start."""
+    def __init__(self, external_id_getter):
+        self._external_id_getter = external_id_getter
+
+    def on_start(self, span, parent_context):
+        try:
+            external_id = None
+            try:
+                external_id = self._external_id_getter()
+            except Exception:
+                external_id = None
+            if external_id:
+                span.set_attribute("ragaai.external_id", str(external_id))
+        except Exception:
+            pass
+
+    def on_end(self, span):
+        return
+
+    def shutdown(self):
+        return True
+
+    def force_flush(self, timeout_millis: int = 30000):
+        return True
 
 class Tracer(AgenticTracing):
     NUM_PROJECTS = 99999
@@ -481,6 +510,13 @@ class Tracer(AgenticTracing):
         Args:
             external_id (str): The new external_id to set
         """
+        # Tag current span to ensure per-trace correctness in concurrent scenarios
+        try:
+            span = otel_trace.get_current_span()
+            if span is not None:
+                span.set_attribute("ragaai.external_id", str(external_id))
+        except Exception as e:
+            logger.debug(f"Unable to set span attribute ragaai.external_id: {e}")
         self.dynamic_exporter.external_id = external_id
         logger.debug(f"Updated dynamic exporter's external_id to {external_id}")
 
@@ -623,6 +659,13 @@ class Tracer(AgenticTracing):
         
         # Set up tracer provider
         tracer_provider = trace_sdk.TracerProvider()
+        # Add processor to stamp external_id on all spans at start
+        try:
+            tracer_provider.add_span_processor(
+                _ExternalIdSpanProcessor(lambda: getattr(self.dynamic_exporter, "external_id", None))
+            )
+        except Exception as e:
+            logger.debug(f"Failed to add ExternalId span processor: {e}")
         tracer_provider.add_span_processor(SimpleSpanProcessor(self.dynamic_exporter))
         
         # Instrument all specified instrumentors


### PR DESCRIPTION
## Problem
In concurrent scenarios, multiple requests were sharing the same external_id due to shared tracer state, resulting in multiple traces having the same external_id

## Solution
- Added contextvars.ContextVar for thread-safe external_id storage
- tracer.set_external_id() now sets context-local value "ragaai.external_id" in span attributes
- ragaai.external_id is also used with trace_id to check unique traces before preparing and uploading a trace
- Each request/thread maintains its own external_id context