### PR TITLE
fix(tracing): set external_id via OpenInference using_attributes(user.id) and promote to top-level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tiktoken>=0.7.0",
     "tomli>=2.0.0",
     "rich>=13.9.4",
+    "openinference-instrumentation",
     "openinference-instrumentation-llama-index",
     "openinference-instrumentation-langchain",
     "openinference-instrumentation-vertexai",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "RAGA AI CATALYST"
 readme = "README.md"
 requires-python = ">=3.10,<=3.13.2"
 # license = {file = "LICENSE"}
-version = "2.2.5.6.beta.2"
+version = "2.2.5.6.beta.3"
 authors = [
     {name = "Kiran Scaria", email = "kiran.scaria@raga.ai"},
     {name = "Kedar Gaikwad", email = "kedar.gaikwad@raga.ai"},

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -163,9 +163,30 @@ class RAGATraceExporter(SpanExporter):
 
     def prepare_trace(self, spans, trace_id):
         try:
+            # Extract external_id from spans via OpenInference user.id (prefer root span)
+            external_id_from_spans = None
             try:
-                ragaai_trace = convert_json_format(spans, self.custom_model_cost, self.user_context, self.user_gt,
-                                                   self.external_id)
+                root_span = next((s for s in spans if s.get("parent_id") is None), None)
+                if root_span:
+                    external_id_from_spans = (
+                        root_span.get("attributes", {}).get("user.id")
+                    )
+                if not external_id_from_spans:
+                    for s in spans:
+                        external_id_from_spans = s.get("attributes", {}).get("user.id")
+                        if external_id_from_spans:
+                            break
+            except Exception:
+                external_id_from_spans = None
+
+            try:
+                ragaai_trace = convert_json_format(
+                    spans,
+                    self.custom_model_cost,
+                    self.user_context,
+                    self.user_gt,
+                    external_id_from_spans if external_id_from_spans else self.external_id,
+                )
             except Exception as e:
                 print(f"Error in convert_json_format function: {trace_id}: {e}")
                 return None


### PR DESCRIPTION
## Problem
- In concurrent scenarios, multiple requests were sharing the same external_id due to shared tracer state, resulting in multiple traces having the same external_id

## Solution
- Use OpenInference using_attributes(user_id=external_id) in user code to tag spans.
- Derive and set top-level external_id from spans’ attributes.user.id in the exporter.
- This implementation require changes in user code, now user have to use ```with using_attributes(user_id = response_id)``` and makes ```set_external_id``` method redundant for this flow.

Reference docs [https://arize.com/docs/ax/observe/tracing/add-metadata/add-attributes-metadata-and-tags](url)
