### PR TITLE
fix: replace '/api' from guardrails v2 end point by empty str if exists

### DIFF
--- a/ragaai_catalyst/guard_executor.py
+++ b/ragaai_catalyst/guard_executor.py
@@ -198,6 +198,7 @@ class GuardExecutor:
             logger.info(f'Using version: {version.lower()}')
         else:
             api = gdm.base_url + f'/guardrails/deployment/{deployment_id}'
+            api = api.replace('/api','')
             logger.info(f'Using version: v2')
         payload = json.dumps(payload)
         headers = {


### PR DESCRIPTION
- replace '/api' from guardrails v2 end point (JS version) by empty str if exists