### PR TITLE
Multi endpoint tracer support

### DIFF
--- a/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/trace_uploader.py
@@ -281,7 +281,6 @@ def process_upload(task_id: str, filepath: str, hash_id: str, zip_path: str,
                     project_name=project_name,
                     project_id=project_id,
                     dataset_name=dataset_name,
-                    user_detail=user_details,
                     base_url=base_url,   
                     timeout=timeout
                 )

--- a/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
+++ b/ragaai_catalyst/tracers/agentic_tracing/upload/upload_agentic_traces.py
@@ -21,7 +21,6 @@ class UploadAgenticTraces:
         project_name,
         project_id,
         dataset_name,
-        user_detail,
         base_url,
         timeout=120,
     ):
@@ -29,7 +28,6 @@ class UploadAgenticTraces:
         self.project_name = project_name
         self.project_id = project_id
         self.dataset_name = dataset_name
-        self.user_detail = user_detail
         self.base_url = base_url
         self.timeout = timeout
 

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -108,23 +108,30 @@ class RAGATraceExporter(SpanExporter):
                 trace_id = span_json.get("context").get("trace_id")
                 if trace_id is None:
                     logger.error("Trace ID is None")
-
-                if trace_id not in self.trace_spans:
-                    self.trace_spans[trace_id] = list()
+                    continue
 
                 if span_json.get("attributes").get("openinference.span.kind", None) is None:
                     span_json["attributes"]["openinference.span.kind"] = "UNKNOWN"
 
-                self.trace_spans[trace_id].append(span_json)
+                # Extract dataset name from span attributes for proper isolation
+                dataset_name = self._get_dataset_from_span(span_json)
 
+                # Create composite key (dataset_name, trace_id) for proper isolation
+                trace_key = (dataset_name, trace_id)
+
+                if trace_key not in self.trace_spans:
+                    self.trace_spans[trace_key] = list()
+
+                self.trace_spans[trace_key].append(span_json)
+                
                 if span_json["parent_id"] is None:
-                    trace = self.trace_spans[trace_id]
+                    trace = self.trace_spans[trace_key]
                     try:
-                        self.process_complete_trace(trace, trace_id)
+                        self.process_complete_trace(trace, trace_id, dataset_name)
                     except Exception as e:
                         logger.error(f"Error processing complete trace: {e}")
                     try:
-                        del self.trace_spans[trace_id]
+                        del self.trace_spans[trace_key]
                     except Exception as e:
                         logger.error(f"Error deleting trace: {e}")
             except Exception as e:
@@ -133,14 +140,82 @@ class RAGATraceExporter(SpanExporter):
 
         return SpanExportResult.SUCCESS
 
+    def _get_dataset_from_span(self, span_json):
+        """
+        Extract dataset name from a single span's attributes.
+        
+        Args:
+            span_json: Single span dictionary
+            
+        Returns:
+            str: Dataset name if found, fallback to original dataset_name otherwise
+        """
+        try:
+            attributes = span_json.get('attributes', {})
+            dataset = attributes.get('ragaai.dataset')
+
+            if dataset:
+                logger.debug(f"Found dataset '{dataset}' in span: {span_json.get('name', 'unnamed')}")
+                return dataset
+            else:
+                # Fallback to original dataset if ragaai.dataset not found
+                logger.debug(f"No ragaai.dataset found in span: {span_json.get('name', 'unnamed')}, using fallback: {self.dataset_name}")
+                return self.dataset_name
+
+        except Exception as e:
+            logger.error(f"Error extracting dataset from span: {e}")
+            return self.dataset_name
+
     def shutdown(self):
         # Process any remaining traces during shutdown
         logger.debug("Reached shutdown of exporter")
-        for trace_id, spans in self.trace_spans.items():
-            self.process_complete_trace(spans, trace_id)
+        for trace_key, spans in self.trace_spans.items():
+            dataset_name, trace_id = trace_key  # Unpack the composite key
+            self.process_complete_trace(spans, trace_id, dataset_name)
         self.trace_spans.clear()
 
-    def process_complete_trace(self, spans, trace_id):
+    def process_complete_trace(self, spans, trace_id, dataset_name=None):
+        """
+        Process a complete trace with the specified dataset.
+        
+        Args:
+            spans: List of span dictionaries for this trace
+            trace_id: The trace ID
+            dataset_name: The dataset name for this trace (from span attributes)
+        """
+        # Use the dataset name from span attributes if provided, otherwise fall back to detection
+        if dataset_name is None:
+            dataset_name = self._get_dataset_from_spans(spans)
+
+        if dataset_name and dataset_name != self.dataset_name:
+            # Temporarily route to the target dataset
+            logger.info(f"Routing trace {trace_id} to dataset: {dataset_name}")
+
+            # Store original values
+            original_dataset = self.dataset_name
+            original_user_details = self.user_details.copy()
+
+            try:
+                # Update dataset for this trace
+                self.dataset_name = dataset_name
+                self.user_details["dataset_name"] = dataset_name
+
+                # Process with updated dataset
+                self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
+
+            finally:
+                # Restore original values
+                self.dataset_name = original_dataset
+                self.user_details = original_user_details
+        else:
+            # Use original dataset
+            logger.debug(f"Trace {trace_id} using original dataset: {self.dataset_name}")
+            self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
+
+    def _process_trace_with_current_dataset(self, spans, trace_id, dataset_name):
+        """
+        Process the trace with the current dataset (original logic from process_complete_trace).
+        """
         # Convert the trace to ragaai trace format
         try:
             ragaai_trace_details = self.prepare_trace(spans, trace_id)
@@ -157,10 +232,38 @@ class RAGATraceExporter(SpanExporter):
         try:
             if self.post_processor != None:
                 ragaai_trace_details['trace_file_path'] = self.post_processor(ragaai_trace_details['trace_file_path'])
-            self.upload_trace(ragaai_trace_details, trace_id)
+            self.upload_trace(ragaai_trace_details, trace_id, dataset_name)
         except Exception as e:
             print(f"Error uploading trace {trace_id}: {e}")
 
+    def _get_dataset_from_spans(self, spans):
+        """
+        Extract dataset name from span attributes.
+        
+        Args:
+            spans: List of span dictionaries
+            
+        Returns:
+            str: Dataset name if found, None otherwise
+        """
+        try:
+            # Look through all spans for the ragaai.dataset attribute
+            for span in spans:
+                attributes = span.get('attributes', {})
+                dataset = attributes.get('ragaai.dataset')
+
+                if dataset:
+                    logger.debug(f"Found dataset '{dataset}' in span: {span.get('name', 'unnamed')}")
+                    return dataset
+
+            # No dataset attribute found
+            logger.debug("No ragaai.dataset attribute found in any span")
+            return None
+
+        except Exception as e:
+            logger.error(f"Error extracting dataset from spans: {e}")
+            return None
+    
     def prepare_trace(self, spans, trace_id):
         try:
             # Extract external_id from spans via OpenInference user.id (prefer root span)
@@ -277,7 +380,7 @@ class RAGATraceExporter(SpanExporter):
             print(f"Error converting trace {trace_id}: {str(e)}")
             return None
 
-    def upload_trace(self, ragaai_trace_details, trace_id):
+    def upload_trace(self, ragaai_trace_details, trace_id, dataset_name):
         filepath = ragaai_trace_details['trace_file_path']
         hash_id = ragaai_trace_details['hash_id']
         zip_path = ragaai_trace_details['code_zip_path']
@@ -287,7 +390,7 @@ class RAGATraceExporter(SpanExporter):
             zip_path=zip_path,
             project_name=self.project_name,
             project_id=self.project_id,
-            dataset_name=self.dataset_name,
+            dataset_name=dataset_name,
             user_details=self.user_details,
             base_url=self.base_url,
             tracer_type=self.tracer_type,

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -153,9 +153,14 @@ class RAGATraceExporter(SpanExporter):
         self.trace_spans.clear()
 
     def process_complete_trace(self, spans: List[Dict[str, Any]], trace_id: str) -> None:
-        self.dataset_name = self._get_dataset_from_spans(spans)
-        
-        self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
+        dataset_name = self._get_dataset_from_spans(spans) or self.dataset_name
+
+        if dataset_name != self.dataset_name:
+            logger.info(f"Routing trace {trace_id} to dataset: {dataset_name} (default: {self.dataset_name})")
+        else:
+            logger.debug(f"Trace {trace_id} using default dataset: {self.dataset_name}")
+
+        self._process_trace_with_current_dataset(spans, trace_id, dataset_name)
 
     def _process_trace_with_current_dataset(self, spans: List[Dict[str, Any]], trace_id: str, dataset_name: Optional[str]) -> None:
         try:

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -153,14 +153,9 @@ class RAGATraceExporter(SpanExporter):
         self.trace_spans.clear()
 
     def process_complete_trace(self, spans, trace_id):
-        dataset_name = self._get_dataset_from_spans(spans) or self.dataset_name
+        self.dataset_name = self._get_dataset_from_spans(spans)
         
-        if dataset_name != self.dataset_name:
-            logger.info(f"Routing trace {trace_id} to dataset: {dataset_name} (default: {self.dataset_name})")
-        else:
-            logger.debug(f"Trace {trace_id} using default dataset: {self.dataset_name}")
-        
-        self._process_trace_with_current_dataset(spans, trace_id, dataset_name)
+        self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
 
     def _process_trace_with_current_dataset(self, spans, trace_id, dataset_name):
         try:

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -114,25 +114,19 @@ class RAGATraceExporter(SpanExporter):
                 if span_json.get("attributes").get("openinference.span.kind", None) is None:
                     span_json["attributes"]["openinference.span.kind"] = "UNKNOWN"
 
-                # Extract dataset name from span attributes for proper isolation, fallback to default if not found
-                dataset_name = self._get_dataset_from_span(span_json) or self.dataset_name
+                if trace_id not in self.trace_spans:
+                    self.trace_spans[trace_id] = list()
 
-                # Create composite key (dataset_name, trace_id) for proper isolation
-                trace_key = (dataset_name, trace_id)
-
-                if trace_key not in self.trace_spans:
-                    self.trace_spans[trace_key] = list()
-
-                self.trace_spans[trace_key].append(span_json)
+                self.trace_spans[trace_id].append(span_json)
                 
                 if span_json["parent_id"] is None:
-                    trace = self.trace_spans[trace_key]
+                    trace = self.trace_spans[trace_id]
                     try:
                         self.process_complete_trace(trace, trace_id)
                     except Exception as e:
                         logger.error(f"Error processing complete trace: {e}")
                     try:
-                        del self.trace_spans[trace_key]
+                        del self.trace_spans[trace_id]
                     except Exception as e:
                         logger.error(f"Error deleting trace: {e}")
             except Exception as e:
@@ -168,8 +162,7 @@ class RAGATraceExporter(SpanExporter):
     def shutdown(self):
         # Process any remaining traces during shutdown
         logger.debug("Reached shutdown of exporter")
-        for trace_key, spans in self.trace_spans.items():
-            _, trace_id = trace_key  # Unpack the composite key
+        for trace_id, spans in self.trace_spans.items():
             self.process_complete_trace(spans, trace_id)
         self.trace_spans.clear()
 

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from dataclasses import asdict
 from datetime import datetime
-from typing import Optional, Callable, Dict, List
+from typing import Any, Optional, Callable, Dict, List, Sequence
 
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
@@ -27,7 +27,7 @@ logging_level = (
 
 
 class TracerJSONEncoder(json.JSONEncoder):
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, datetime):
             return obj.isoformat()
         if isinstance(obj, bytes):
@@ -131,7 +131,7 @@ class RAGATraceExporter(SpanExporter):
 
         return SpanExportResult.SUCCESS
 
-    def _get_dataset_from_span(self, span_json):
+    def _get_dataset_from_span(self, span_json: Dict[str, Any]) -> Optional[str]:
         try:
             dataset = span_json.get("attributes", {}).get("ragaai.dataset")
             
@@ -146,18 +146,18 @@ class RAGATraceExporter(SpanExporter):
             logger.error(f"Error extracting dataset from span: {e}")
             return None
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         logger.debug("Reached shutdown of exporter")
         for trace_id, spans in self.trace_spans.items():
             self.process_complete_trace(spans, trace_id)
         self.trace_spans.clear()
 
-    def process_complete_trace(self, spans, trace_id):
+    def process_complete_trace(self, spans: List[Dict[str, Any]], trace_id: str) -> None:
         self.dataset_name = self._get_dataset_from_spans(spans)
         
         self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
 
-    def _process_trace_with_current_dataset(self, spans, trace_id, dataset_name):
+    def _process_trace_with_current_dataset(self, spans: List[Dict[str, Any]], trace_id: str, dataset_name: Optional[str]) -> None:
         try:
             ragaai_trace_details = self.prepare_trace(spans, trace_id)
         except Exception as e:
@@ -175,7 +175,7 @@ class RAGATraceExporter(SpanExporter):
         except Exception as e:
             print(f"Error uploading trace {trace_id}: {e}")
 
-    def _get_dataset_from_spans(self, spans):
+    def _get_dataset_from_spans(self, spans: List[Dict[str, Any]]) -> Optional[str]:
         try:
             for span in spans:
                 dataset = span.get('attributes', {}).get('ragaai.dataset')
@@ -191,7 +191,7 @@ class RAGATraceExporter(SpanExporter):
             logger.error(f"Error extracting dataset from spans: {e}")
             return None
     
-    def prepare_trace(self, spans, trace_id):
+    def prepare_trace(self, spans: List[Dict[str, Any]], trace_id: str) -> Optional[Dict[str, Any]]:
         try:
             external_id_from_spans = None
             try:
@@ -302,7 +302,7 @@ class RAGATraceExporter(SpanExporter):
             print(f"Error converting trace {trace_id}: {str(e)}")
             return None
 
-    def upload_trace(self, ragaai_trace_details, trace_id, dataset_name):
+    def upload_trace(self, ragaai_trace_details: Dict[str, Any], trace_id: str, dataset_name: Optional[str]) -> None:
         filepath = ragaai_trace_details['trace_file_path']
         hash_id = ragaai_trace_details['hash_id']
         zip_path = ragaai_trace_details['code_zip_path']

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -3,6 +3,7 @@ import logging
 import os
 import tempfile
 from dataclasses import asdict
+from datetime import datetime
 from typing import Optional, Callable, Dict, List
 
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -113,8 +114,8 @@ class RAGATraceExporter(SpanExporter):
                 if span_json.get("attributes").get("openinference.span.kind", None) is None:
                     span_json["attributes"]["openinference.span.kind"] = "UNKNOWN"
 
-                # Extract dataset name from span attributes for proper isolation
-                dataset_name = self._get_dataset_from_span(span_json)
+                # Extract dataset name from span attributes for proper isolation, fallback to default if not found
+                dataset_name = self._get_dataset_from_span(span_json) or self.dataset_name
 
                 # Create composite key (dataset_name, trace_id) for proper isolation
                 trace_key = (dataset_name, trace_id)
@@ -127,7 +128,7 @@ class RAGATraceExporter(SpanExporter):
                 if span_json["parent_id"] is None:
                     trace = self.trace_spans[trace_key]
                     try:
-                        self.process_complete_trace(trace, trace_id, dataset_name)
+                        self.process_complete_trace(trace, trace_id)
                     except Exception as e:
                         logger.error(f"Error processing complete trace: {e}")
                     try:
@@ -148,69 +149,49 @@ class RAGATraceExporter(SpanExporter):
             span_json: Single span dictionary
             
         Returns:
-            str: Dataset name if found, fallback to original dataset_name otherwise
+            str: Dataset name if found, None otherwise
         """
         try:
-            attributes = span_json.get('attributes', {})
-            dataset = attributes.get('ragaai.dataset')
-
+            dataset = span_json.get("attributes", {}).get("ragaai.dataset")
+            
             if dataset:
                 logger.debug(f"Found dataset '{dataset}' in span: {span_json.get('name', 'unnamed')}")
                 return dataset
-            else:
-                # Fallback to original dataset if ragaai.dataset not found
-                logger.debug(f"No ragaai.dataset found in span: {span_json.get('name', 'unnamed')}, using fallback: {self.dataset_name}")
-                return self.dataset_name
+            
+            logger.debug(f"No ragaai.dataset found in span: {span_json.get('name', 'unnamed')}")
+            return None
 
         except Exception as e:
             logger.error(f"Error extracting dataset from span: {e}")
-            return self.dataset_name
+            return None
 
     def shutdown(self):
         # Process any remaining traces during shutdown
         logger.debug("Reached shutdown of exporter")
         for trace_key, spans in self.trace_spans.items():
-            dataset_name, trace_id = trace_key  # Unpack the composite key
-            self.process_complete_trace(spans, trace_id, dataset_name)
+            _, trace_id = trace_key  # Unpack the composite key
+            self.process_complete_trace(spans, trace_id)
         self.trace_spans.clear()
 
-    def process_complete_trace(self, spans, trace_id, dataset_name=None):
+    def process_complete_trace(self, spans, trace_id):
         """
         Process a complete trace with the specified dataset.
         
         Args:
             spans: List of span dictionaries for this trace
             trace_id: The trace ID
-            dataset_name: The dataset name for this trace (from span attributes)
         """
-        # Use the dataset name from span attributes if provided, otherwise fall back to detection
-        if dataset_name is None:
-            dataset_name = self._get_dataset_from_spans(spans)
-
-        if dataset_name and dataset_name != self.dataset_name:
-            # Temporarily route to the target dataset
-            logger.info(f"Routing trace {trace_id} to dataset: {dataset_name}")
-
-            # Store original values
-            original_dataset = self.dataset_name
-            original_user_details = self.user_details.copy()
-
-            try:
-                # Update dataset for this trace
-                self.dataset_name = dataset_name
-                self.user_details["dataset_name"] = dataset_name
-
-                # Process with updated dataset
-                self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
-
-            finally:
-                # Restore original values
-                self.dataset_name = original_dataset
-                self.user_details = original_user_details
+        # Extract dataset from span attributes, fallback to default if not found
+        dataset_name = self._get_dataset_from_spans(spans) or self.dataset_name
+        
+        # Log which dataset is being used
+        if dataset_name != self.dataset_name:
+            logger.info(f"Routing trace {trace_id} to dataset: {dataset_name} (default: {self.dataset_name})")
         else:
-            # Use original dataset
-            logger.debug(f"Trace {trace_id} using original dataset: {self.dataset_name}")
-            self._process_trace_with_current_dataset(spans, trace_id, self.dataset_name)
+            logger.debug(f"Trace {trace_id} using default dataset: {self.dataset_name}")
+        
+        # Process trace with the determined dataset (no state mutation needed)
+        self._process_trace_with_current_dataset(spans, trace_id, dataset_name)
 
     def _process_trace_with_current_dataset(self, spans, trace_id, dataset_name):
         """
@@ -249,14 +230,12 @@ class RAGATraceExporter(SpanExporter):
         try:
             # Look through all spans for the ragaai.dataset attribute
             for span in spans:
-                attributes = span.get('attributes', {})
-                dataset = attributes.get('ragaai.dataset')
-
+                dataset = span.get('attributes', {}).get('ragaai.dataset')
+                
                 if dataset:
                     logger.debug(f"Found dataset '{dataset}' in span: {span.get('name', 'unnamed')}")
                     return dataset
 
-            # No dataset attribute found
             logger.debug("No ragaai.dataset attribute found in any span")
             return None
 

--- a/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
+++ b/ragaai_catalyst/tracers/exporters/ragaai_trace_exporter.py
@@ -34,21 +34,19 @@ class TracerJSONEncoder(json.JSONEncoder):
             try:
                 return obj.decode("utf-8")
             except UnicodeDecodeError:
-                return str(obj)  # Fallback to string representation
-        if hasattr(obj, "to_dict"):  # Handle objects with to_dict method
+                return str(obj)
+        if hasattr(obj, "to_dict"):
             return obj.to_dict()
         if hasattr(obj, "__dict__"):
-            # Filter out None values and handle nested serialization
             return {
                 k: v
                 for k, v in obj.__dict__.items()
                 if v is not None and not k.startswith("_")
             }
         try:
-            # Try to convert to a basic type
             return str(obj)
         except:
-            return None  # Last resort: return None instead of failing
+            return None
 
 
 class RAGATraceExporter(SpanExporter):
@@ -70,11 +68,9 @@ class RAGATraceExporter(SpanExporter):
             external_id: Optional[str] = None
     ):
         self.trace_spans = dict()
-        # Use custom trace directory if environment variable is set, otherwise use temp directory
         custom_dir = os.getenv("RAGAAI_TRACE_DIR")
         if custom_dir:
             try:
-                # Create the directory if it doesn't exist
                 os.makedirs(custom_dir, exist_ok=True)
                 self.tmp_dir = custom_dir
                 logger.info(f"Using custom trace directory: {custom_dir}")
@@ -136,15 +132,6 @@ class RAGATraceExporter(SpanExporter):
         return SpanExportResult.SUCCESS
 
     def _get_dataset_from_span(self, span_json):
-        """
-        Extract dataset name from a single span's attributes.
-        
-        Args:
-            span_json: Single span dictionary
-            
-        Returns:
-            str: Dataset name if found, None otherwise
-        """
         try:
             dataset = span_json.get("attributes", {}).get("ragaai.dataset")
             
@@ -160,49 +147,32 @@ class RAGATraceExporter(SpanExporter):
             return None
 
     def shutdown(self):
-        # Process any remaining traces during shutdown
         logger.debug("Reached shutdown of exporter")
         for trace_id, spans in self.trace_spans.items():
             self.process_complete_trace(spans, trace_id)
         self.trace_spans.clear()
 
     def process_complete_trace(self, spans, trace_id):
-        """
-        Process a complete trace with the specified dataset.
-        
-        Args:
-            spans: List of span dictionaries for this trace
-            trace_id: The trace ID
-        """
-        # Extract dataset from span attributes, fallback to default if not found
         dataset_name = self._get_dataset_from_spans(spans) or self.dataset_name
         
-        # Log which dataset is being used
         if dataset_name != self.dataset_name:
             logger.info(f"Routing trace {trace_id} to dataset: {dataset_name} (default: {self.dataset_name})")
         else:
             logger.debug(f"Trace {trace_id} using default dataset: {self.dataset_name}")
         
-        # Process trace with the determined dataset (no state mutation needed)
         self._process_trace_with_current_dataset(spans, trace_id, dataset_name)
 
     def _process_trace_with_current_dataset(self, spans, trace_id, dataset_name):
-        """
-        Process the trace with the current dataset (original logic from process_complete_trace).
-        """
-        # Convert the trace to ragaai trace format
         try:
             ragaai_trace_details = self.prepare_trace(spans, trace_id)
         except Exception as e:
             print(f"Error converting trace {trace_id}: {e}")
-            return  # Exit early if conversion fails
+            return
 
-        # Check if trace details are None (conversion failed)
         if ragaai_trace_details is None:
             logger.error(f"Cannot upload trace {trace_id}: conversion failed and returned None")
-            return  # Exit early if conversion failed
+            return
 
-        # Upload the trace if upload_trace function is provided
         try:
             if self.post_processor != None:
                 ragaai_trace_details['trace_file_path'] = self.post_processor(ragaai_trace_details['trace_file_path'])
@@ -211,17 +181,7 @@ class RAGATraceExporter(SpanExporter):
             print(f"Error uploading trace {trace_id}: {e}")
 
     def _get_dataset_from_spans(self, spans):
-        """
-        Extract dataset name from span attributes.
-        
-        Args:
-            spans: List of span dictionaries
-            
-        Returns:
-            str: Dataset name if found, None otherwise
-        """
         try:
-            # Look through all spans for the ragaai.dataset attribute
             for span in spans:
                 dataset = span.get('attributes', {}).get('ragaai.dataset')
                 
@@ -238,7 +198,6 @@ class RAGATraceExporter(SpanExporter):
     
     def prepare_trace(self, spans, trace_id):
         try:
-            # Extract external_id from spans via OpenInference user.id (prefer root span)
             external_id_from_spans = None
             try:
                 root_span = next((s for s in spans if s.get("parent_id") is None), None)
@@ -274,7 +233,6 @@ class RAGATraceExporter(SpanExporter):
                 return None
 
             try:
-                # Add source code hash
                 hash_id, zip_path = zip_list_of_unique_files(
                     self.files_to_zip, output_dir=self.tmp_dir
                 )
@@ -309,13 +267,11 @@ class RAGATraceExporter(SpanExporter):
                 return None
 
             try:
-                # Add tracer type to the trace
                 ragaai_trace["tracer_type"] = self.tracer_type
             except Exception as e:
                 print(f"Error in adding tracer type: {trace_id}: {e}")
                 return None
 
-            # Add user passed metadata to the trace
             try:
                 logger.debug("Started adding user passed metadata")
 
@@ -335,7 +291,6 @@ class RAGATraceExporter(SpanExporter):
                 return None
 
             try:
-                # Save the trace_json 
                 trace_file_path = os.path.join(self.tmp_dir, f"{trace_id}.json")
                 with open(trace_file_path, "w") as file:
                     json.dump(ragaai_trace, file, cls=TracerJSONEncoder, indent=2)

--- a/ragaai_catalyst/tracers/processors/dataset_span_processor.py
+++ b/ragaai_catalyst/tracers/processors/dataset_span_processor.py
@@ -1,0 +1,93 @@
+"""
+Dataset Span Processor - Automatically adds dataset attributes to spans.
+
+This processor automatically sets the 'ragaai.dataset' attribute on every span
+based on the dataset_name from the tracer initialization or context variables for per-request isolation.
+"""
+
+import logging
+from opentelemetry.sdk.trace import SpanProcessor
+from opentelemetry import context
+
+logger = logging.getLogger("RagaAICatalyst")
+
+class DatasetSpanProcessor(SpanProcessor):
+    """
+    A SpanProcessor that automatically adds dataset routing attributes to spans.
+    
+    This ensures that every span gets the 'ragaai.dataset' attribute set to the 
+    dataset_name that was provided when the tracer was initialized, or from the
+    current request context for per-request isolation.
+    """
+    
+    def __init__(self, dataset_name):
+        """
+        Initialize the DatasetSpanProcessor.
+        
+        Args:
+            dataset_name (str): The default dataset name to set on spans (fallback)
+        """
+        self.default_dataset_name = dataset_name
+        logger.debug(f"DatasetSpanProcessor initialized with default dataset: {dataset_name}")
+    
+    def on_start(self, span, parent_context=None):
+        """
+        Called when a span starts. Automatically set the dataset attribute.
+        
+        Args:
+            span: The span that is starting
+            parent_context: The parent context (optional)
+        """
+        try:
+            if span and span.is_recording():
+                # First try to get dataset name from current context (per-request)
+                dataset_name = context.get_value("ragaai.dataset_name")
+                
+                if dataset_name is None:
+                    # Fallback to default dataset name if context is not set
+                    dataset_name = self.default_dataset_name
+                    logger.debug(f"Using default dataset '{dataset_name}' for span: {span.name}")
+                else:
+                    logger.debug(f"Using context dataset '{dataset_name}' for span: {span.name}")
+                
+                # Set the dataset attribute on the span
+                span.set_attribute("ragaai.dataset", dataset_name)
+                
+                # Add context source indicator for debugging
+                context_source = "context" if context.get_value("ragaai.dataset_name") else "default"
+                span.set_attribute("ragaai.dataset_source", context_source)
+                
+                logger.debug(f"Set dataset attribute '{dataset_name}' on span: {span.name} (source: {context_source})")
+            
+        except Exception as e:
+            logger.warning(f"Error setting dataset attribute on span: {e}")
+    
+    def on_end(self, span):
+        """
+        Called when a span ends. No action needed for dataset routing.
+        
+        Args:
+            span: The span that is ending
+        """
+        pass
+    
+    def shutdown(self):
+        """Shutdown the processor."""
+        pass
+    
+    def force_flush(self, timeout_millis=None):
+        """Force flush the processor."""
+        pass
+    
+    def update_dataset_name(self, new_dataset_name):
+        """
+        Update the default dataset name for future spans.
+        Note: This method is kept for backward compatibility but context variables take precedence.
+        
+        Args:
+            new_dataset_name (str): New default dataset name to use
+        """
+        old_dataset = self.default_dataset_name
+        self.default_dataset_name = new_dataset_name
+        logger.info(f"Updated default dataset from '{old_dataset}' to '{new_dataset_name}'")
+        logger.info("Note: Context variables will take precedence over this default value") 

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -25,6 +25,8 @@ from http.client import RemoteDisconnected
 from ragaai_catalyst.tracers.agentic_tracing import AgenticTracing
 from ragaai_catalyst.tracers.exporters.ragaai_trace_exporter import RAGATraceExporter
 from ragaai_catalyst.tracers.agentic_tracing.utils.file_name_tracker import TrackName
+from ragaai_catalyst.tracers.processors.dataset_span_processor import DatasetSpanProcessor
+from opentelemetry import context
 
 logger = logging.getLogger(__name__)
 logging_level = (
@@ -448,12 +450,24 @@ class Tracer(AgenticTracing):
 
     def set_dataset_name(self, dataset_name):
         """
-        This method updates the dataset_name attribute of the dynamic exporter.
+        This method sets the dataset name for the current request context using OpenTelemetry context variables.
+        This ensures proper isolation between concurrent requests with different dataset names.
         Args:
-            dataset_name (str): The new dataset name to set
+            dataset_name (str): The new dataset name to set for current request context
         """
+        # Set the dataset name in the current request context (thread-safe)
+        ctx = context.set_value("ragaai.dataset_name", dataset_name)
+        token = context.attach(ctx)
+        logger.debug(f"Set dataset context variable to '{dataset_name}' for current request")
+
+        # update the dynamic exporter for backward compatibility with non-context-aware components
         self.dynamic_exporter.dataset_name = dataset_name
         logger.debug(f"Updated dynamic exporter's dataset_name to {dataset_name}")
+
+        # Update the tracer's own dataset_name (fallback)
+        self.dataset_name = dataset_name
+
+        logger.debug(f"Dataset name set via context variables for request-level isolation")
 
     def _improve_metadata(self, metadata, tracer_type):
         if metadata is None:
@@ -552,6 +566,7 @@ class Tracer(AgenticTracing):
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor
         from ragaai_catalyst.tracers.exporters.dynamic_trace_exporter import DynamicTraceExporter
         from openinference.instrumentation import TracerProvider, TraceConfig
+        from ragaai_catalyst.tracers.processors.dataset_span_processor import DatasetSpanProcessor
 
         # Get the code_files
         self.file_tracker.trace_main_file()
@@ -574,9 +589,16 @@ class Tracer(AgenticTracing):
             user_gt = self.user_gt,
             external_id=self.external_id
         )
-        
+
+        # Create dataset span processor to automatically set dataset attributes
+        self.dataset_processor = DatasetSpanProcessor(self.dataset_name)
+
         # Set up tracer provider
         tracer_provider = TracerProvider(config=TraceConfig())
+        
+        # Add dataset processor first to set attributes on span start
+        tracer_provider.add_span_processor(self.dataset_processor)
+        
         tracer_provider.add_span_processor(SimpleSpanProcessor(self.dynamic_exporter))
         
         # Instrument all specified instrumentors
@@ -590,7 +612,9 @@ class Tracer(AgenticTracing):
             
             # Instrument with the provided tracer provider and arguments
             instrumentor.instrument(tracer_provider=tracer_provider, *args)
-
+        
+        logger.info(f"Agentic tracer setup complete with automatic dataset routing - dataset: {self.dataset_name}")
+        
         return tracer_provider.get_tracer(__name__)
 
     def update_file_list(self):

--- a/ragaai_catalyst/tracers/tracer.py
+++ b/ragaai_catalyst/tracers/tracer.py
@@ -464,11 +464,6 @@ class Tracer(AgenticTracing):
         self.dynamic_exporter.dataset_name = dataset_name
         logger.debug(f"Updated dynamic exporter's dataset_name to {dataset_name}")
 
-        # Update the tracer's own dataset_name (fallback)
-        self.dataset_name = dataset_name
-
-        logger.debug(f"Dataset name set via context variables for request-level isolation")
-
     def _improve_metadata(self, metadata, tracer_type):
         if metadata is None:
             metadata = {}


### PR DESCRIPTION
## Description
This PR addresses a critical concurrency issue where multiple requests with different dataset names were interfering with each other due to shared global state.

## Related Issue
When running concurrent requests to different endpoints, all traces were ending up with the same dataset name or getting mismatched due to a race condition
<img width="499" height="327" alt="Screenshot 2025-11-28 at 6 59 29 PM" src="https://github.com/user-attachments/assets/b3094ae3-cceb-4b2c-be52-a68c179f4b07" />

## Type of Change
- set context variables using OpenTelemetry context
- Introduces a new DatasetSpanProcessor class that automatically sets dataset attributes on spans
- Groups spans by (dataset_name, trace_id) for proper isolation instead of only trace_id