### PR TITLE
fix: add addColumnType and promptDetails in add column payload

### DIFF
--- a/ragaai_catalyst/dataset.py
+++ b/ragaai_catalyst/dataset.py
@@ -564,8 +564,10 @@ class Dataset:
             add_column_payload = {
                 "rowFilterList": [],
                 "columnName": column_name,
+                "addColumnType": "RUN_PROMPT",
                 "datasetId": dataset_id,
                 "variables": variables,
+                "promptDetails": {},
                 "promptTemplate": {
                     "textFields": text_fields,
                     "modelSpecs": {

--- a/ragaai_catalyst/prompt_manager.py
+++ b/ragaai_catalyst/prompt_manager.py
@@ -1,5 +1,5 @@
 import os
-from sys import exception
+# from sys import exception
 
 import requests
 import json


### PR DESCRIPTION
## Description
- This PR fixes a minor bug due to change in the response structure for add_column feature
- Earlier `addColumnType` and `promptDetails` were not present in the response, now added as a fix